### PR TITLE
AB#26928 check Harbor

### DIFF
--- a/.github/actions/Resolve-Harbor-Artifact/action.yml
+++ b/.github/actions/Resolve-Harbor-Artifact/action.yml
@@ -1,0 +1,75 @@
+name: 'Resolve Harbor Artifact'
+description: 'Find a Harbor artifact by commit SHA or existing Harbor tag, then choose a reusable image tag.'
+inputs:
+  harbor_base_url:
+    description: 'Harbor base URL (for example: https://harbor.mt-ss.cdcr.ca.gov)'
+    required: false
+    default: 'https://harbor.mt-ss.cdcr.ca.gov'
+  harbor_project:
+    description: 'Harbor project name'
+    required: false
+    default: 'workloads'
+  harbor_repository:
+    description: 'Harbor repository name inside the project'
+    required: true
+  commit_sha:
+    description: 'Commit SHA to match against extra_attrs.config.Labels.GitInfo.commitId'
+    required: false
+  harbor_tag:
+    description: 'Harbor tag to match on artifacts when commit_sha is not provided'
+    required: false
+  registry_token:
+    description: 'Optional Harbor auth token (Bearer token or user:pass)'
+    required: false
+  ignore_tag_pattern:
+    description: 'Case-insensitive regex for tags that should never be selected'
+    required: false
+    default: '^latest$'
+  alias_tag_pattern:
+    description: 'Case-insensitive regex for dynamic alias tags that should be deprioritized'
+    required: false
+    default: '^(rc\\.|r\\.|buildall\\.)'
+outputs:
+  found_match:
+    description: 'true when a reusable artifact+tag was selected, else false'
+    value: ${{ steps.resolve.outputs.found_match }}
+  lookup_failed:
+    description: 'true when Harbor API lookup failed, else false'
+    value: ${{ steps.resolve.outputs.lookup_failed }}
+  selected_tag:
+    description: 'The selected reusable Harbor tag'
+    value: ${{ steps.resolve.outputs.selected_tag }}
+  version_number:
+    description: 'Alias of selected_tag for version-style consumers'
+    value: ${{ steps.resolve.outputs.version_number }}
+  build_sha:
+    description: 'Commit SHA read from the selected artifact metadata'
+    value: ${{ steps.resolve.outputs.build_sha }}
+  image_ref:
+    description: 'Full image reference for the selected tag'
+    value: ${{ steps.resolve.outputs.image_ref }}
+  artifact_digest:
+    description: 'Digest of the selected artifact'
+    value: ${{ steps.resolve.outputs.artifact_digest }}
+  artifact_push_time:
+    description: 'Push time of the selected artifact'
+    value: ${{ steps.resolve.outputs.artifact_push_time }}
+  matched_by:
+    description: 'Lookup strategy used (commit_sha or harbor_tag)'
+    value: ${{ steps.resolve.outputs.matched_by }}
+runs:
+  using: 'composite'
+  steps:
+    - id: resolve
+      shell: bash
+      run: |
+        bash "${{ github.action_path }}/resolve_harbor_artifact.sh"
+      env:
+        INPUT_HARBOR_BASE_URL: ${{ inputs.harbor_base_url }}
+        INPUT_HARBOR_PROJECT: ${{ inputs.harbor_project }}
+        INPUT_HARBOR_REPOSITORY: ${{ inputs.harbor_repository }}
+        INPUT_COMMIT_SHA: ${{ inputs.commit_sha }}
+        INPUT_HARBOR_TAG: ${{ inputs.harbor_tag }}
+        INPUT_REGISTRY_TOKEN: ${{ inputs.registry_token }}
+        INPUT_IGNORE_TAG_PATTERN: ${{ inputs.ignore_tag_pattern }}
+        INPUT_ALIAS_TAG_PATTERN: ${{ inputs.alias_tag_pattern }}

--- a/.github/actions/Resolve-Harbor-Artifact/resolve_harbor_artifact.sh
+++ b/.github/actions/Resolve-Harbor-Artifact/resolve_harbor_artifact.sh
@@ -72,7 +72,7 @@ call_harbor_api() {
 
     if [[ "${registry_token}" == *:* ]]; then
       local basic_auth
-      basic_auth=$(printf "%s" "${registry_token}" | base64 -w 0)
+      basic_auth=$(printf "%s" "${registry_token}" | base64 | tr -d '\n')
       http_code=$(curl -sS -k -o "${response_file}" -w "%{http_code}" -H "Authorization: Basic ${basic_auth}" "${url}")
       if [[ "${http_code}" == "200" ]]; then
         echo "${http_code}"

--- a/.github/actions/Resolve-Harbor-Artifact/resolve_harbor_artifact.sh
+++ b/.github/actions/Resolve-Harbor-Artifact/resolve_harbor_artifact.sh
@@ -85,6 +85,20 @@ call_harbor_api() {
   return 1
 }
 
+jq_git_commit_id_def='
+  def git_commit_id:
+    .extra_attrs.config.Labels.GitInfo? as $gitinfo
+    | if ($gitinfo | type) != "string" then
+        ""
+      else
+        (
+          ($gitinfo | fromjson? | .commitId)
+          // (($gitinfo | try capture("commitId:[[:space:]]*'"'"'(?<commitId>[^'"'"']*)'"'"'") catch {}) | .commitId)
+          // ""
+        )
+      end;
+'
+
 page=1
 page_size=100
 all_artifacts='[]'
@@ -132,12 +146,12 @@ if [[ "${lookup_failed}" == "true" ]]; then
   exit 0
 fi
 
-echo "All artifact commitIds: $(jq -r '[.[].extra_attrs.config.Labels.GitInfo | fromjson? | .commitId // ""] | join(", ")' <<< "${all_artifacts}")"
+echo "All artifact commitIds: $(jq -r "${jq_git_commit_id_def} [ .[] | git_commit_id ] | join(\", \")" <<< "${all_artifacts}")"
 
 if [[ "${match_mode}" == "commit_sha" ]]; then
-  matching_artifacts=$(jq -c --arg commit "${commit_sha}" '
-    map(select(((.extra_attrs.config.Labels.GitInfo | fromjson? | .commitId) // "") == $commit))
-  ' <<< "${all_artifacts}")
+  matching_artifacts=$(jq -c --arg commit "${commit_sha}" "${jq_git_commit_id_def}
+    map(select(git_commit_id == \$commit))
+  " <<< "${all_artifacts}")
 else
   matching_artifacts=$(jq -c --arg tag "${harbor_tag}" '
     map(select(any((.tags // [])[]?; (.name // "") == $tag)))
@@ -187,7 +201,7 @@ if [[ -z "${selected_tag}" ]]; then
   exit 0
 fi
 
-build_sha=$(jq -r '(.extra_attrs.config.Labels.GitInfo | fromjson? | .commitId) // ""' <<< "${selected_artifact}")
+build_sha=$(jq -r "${jq_git_commit_id_def} git_commit_id" <<< "${selected_artifact}")
 artifact_digest=$(jq -r '.digest // ""' <<< "${selected_artifact}")
 artifact_push_time=$(jq -r '.push_time // ""' <<< "${selected_artifact}")
 image_ref="${harbor_base_url#https://}/${harbor_project}/${harbor_repository}:${selected_tag}"

--- a/.github/actions/Resolve-Harbor-Artifact/resolve_harbor_artifact.sh
+++ b/.github/actions/Resolve-Harbor-Artifact/resolve_harbor_artifact.sh
@@ -90,6 +90,7 @@ lookup_failed='false'
 while true; do
   url="${harbor_base_url}/api/v2.0/projects/${project_uri}/repositories/${repo_uri}/artifacts?page=${page}&page_size=${page_size}&with_tag=true"
   echo "url:  ${url}"
+  nslookup harbor.mt-ss.cdcr.ca.gov
   response_file=$(mktemp)
 
   if ! http_code=$(call_harbor_api "${url}" "${response_file}"); then

--- a/.github/actions/Resolve-Harbor-Artifact/resolve_harbor_artifact.sh
+++ b/.github/actions/Resolve-Harbor-Artifact/resolve_harbor_artifact.sh
@@ -91,14 +91,17 @@ while true; do
   url="${harbor_base_url}/api/v2.0/projects/${project_uri}/repositories/${repo_uri}/artifacts?page=${page}&page_size=${page_size}&with_tag=true"
   echo "url:  ${url}"
   nslookup harbor.mt-ss.cdcr.ca.gov 2>/dev/null || true
+  echo "***** after nslookup"
   response_file=$(mktemp)
 
   if ! http_code=$(call_harbor_api "${url}" "${response_file}"); then
+    echo "***** lookup failed"
     lookup_failed='true'
     echo "Harbor lookup failed on page ${page} with HTTP ${http_code}."
     rm -f "${response_file}"
     break
   fi
+  echo "***** lookup succeeded"
 
   page_artifacts=$(cat "${response_file}")
   rm -f "${response_file}"

--- a/.github/actions/Resolve-Harbor-Artifact/resolve_harbor_artifact.sh
+++ b/.github/actions/Resolve-Harbor-Artifact/resolve_harbor_artifact.sh
@@ -90,7 +90,7 @@ lookup_failed='false'
 while true; do
   url="${harbor_base_url}/api/v2.0/projects/${project_uri}/repositories/${repo_uri}/artifacts?page=${page}&page_size=${page_size}&with_tag=true"
   echo "url:  ${url}"
-  nslookup harbor.mt-ss.cdcr.ca.gov
+  nslookup harbor.mt-ss.cdcr.ca.gov 2>/dev/null
   response_file=$(mktemp)
 
   if ! http_code=$(call_harbor_api "${url}" "${response_file}"); then

--- a/.github/actions/Resolve-Harbor-Artifact/resolve_harbor_artifact.sh
+++ b/.github/actions/Resolve-Harbor-Artifact/resolve_harbor_artifact.sh
@@ -1,0 +1,190 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+harbor_base_url="${INPUT_HARBOR_BASE_URL:-https://harbor.mt-ss.cdcr.ca.gov}"
+harbor_project="${INPUT_HARBOR_PROJECT:-workloads}"
+harbor_repository="${INPUT_HARBOR_REPOSITORY:-}"
+commit_sha="${INPUT_COMMIT_SHA:-}"
+harbor_tag="${INPUT_HARBOR_TAG:-}"
+registry_token="${INPUT_REGISTRY_TOKEN:-}"
+ignore_tag_pattern="${INPUT_IGNORE_TAG_PATTERN:-^latest$}"
+alias_tag_pattern="${INPUT_ALIAS_TAG_PATTERN:-^(rc\\.|r\\.|buildall\\.)}"
+
+write_empty_outputs() {
+  {
+    echo "found_match=false"
+    echo "selected_tag="
+    echo "version_number="
+    echo "build_sha="
+    echo "image_ref="
+    echo "artifact_digest="
+    echo "artifact_push_time="
+  } >> "$GITHUB_OUTPUT"
+}
+
+if [[ -z "${harbor_repository}" ]]; then
+  echo "INPUT_HARBOR_REPOSITORY is required." >&2
+  exit 1
+fi
+
+if [[ -z "${commit_sha}" && -z "${harbor_tag}" ]]; then
+  echo "One of commit_sha or harbor_tag must be provided." >&2
+  exit 1
+fi
+
+if [[ -n "${commit_sha}" ]]; then
+  match_mode="commit_sha"
+else
+  match_mode="harbor_tag"
+fi
+
+echo "matched_by=${match_mode}" >> "$GITHUB_OUTPUT"
+echo "lookup_failed=false" >> "$GITHUB_OUTPUT"
+
+auth_args=()
+if [[ -n "${registry_token}" ]]; then
+  auth_args+=("-H" "Authorization: Bearer ${registry_token}")
+fi
+
+project_uri=$(jq -rn --arg v "${harbor_project}" '$v|@uri')
+repo_uri=$(jq -rn --arg v "${harbor_repository}" '$v|@uri')
+
+call_harbor_api() {
+  local url="$1"
+  local response_file="$2"
+  local http_code
+
+  http_code=$(curl -sS -k -o "${response_file}" -w "%{http_code}" "${url}")
+  if [[ "${http_code}" == "200" ]]; then
+    echo "${http_code}"
+    return 0
+  fi
+
+  if [[ ${#auth_args[@]} -gt 0 ]]; then
+    http_code=$(curl -sS -k -o "${response_file}" -w "%{http_code}" "${auth_args[@]}" "${url}")
+    if [[ "${http_code}" == "200" ]]; then
+      echo "${http_code}"
+      return 0
+    fi
+
+    if [[ "${registry_token}" == *:* ]]; then
+      local basic_auth
+      basic_auth=$(printf "%s" "${registry_token}" | base64 -w 0)
+      http_code=$(curl -sS -k -o "${response_file}" -w "%{http_code}" -H "Authorization: Basic ${basic_auth}" "${url}")
+      if [[ "${http_code}" == "200" ]]; then
+        echo "${http_code}"
+        return 0
+      fi
+    fi
+  fi
+
+  echo "${http_code}"
+  return 1
+}
+
+page=1
+page_size=100
+all_artifacts='[]'
+lookup_failed='false'
+
+while true; do
+  url="${harbor_base_url}/api/v2.0/projects/${project_uri}/repositories/${repo_uri}/artifacts?page=${page}&page_size=${page_size}&with_tag=true"
+  response_file=$(mktemp)
+
+  if ! http_code=$(call_harbor_api "${url}" "${response_file}"); then
+    lookup_failed='true'
+    echo "Harbor lookup failed on page ${page} with HTTP ${http_code}."
+    rm -f "${response_file}"
+    break
+  fi
+
+  page_artifacts=$(cat "${response_file}")
+  rm -f "${response_file}"
+
+  page_count=$(jq 'length' <<< "${page_artifacts}")
+  if [[ "${page_count}" -eq 0 ]]; then
+    break
+  fi
+
+  all_artifacts=$(jq -c --argjson newPage "${page_artifacts}" '. + $newPage' <<< "${all_artifacts}")
+
+  if [[ "${page_count}" -lt "${page_size}" ]]; then
+    break
+  fi
+
+  page=$((page + 1))
+done
+
+if [[ "${lookup_failed}" == "true" ]]; then
+  echo "lookup_failed=true" >> "$GITHUB_OUTPUT"
+  write_empty_outputs
+  exit 0
+fi
+
+if [[ "${match_mode}" == "commit_sha" ]]; then
+  matching_artifacts=$(jq -c --arg commit "${commit_sha}" '
+    map(select((.extra_attrs.config.Labels.GitInfo.commitId // "") == $commit))
+  ' <<< "${all_artifacts}")
+else
+  matching_artifacts=$(jq -c --arg tag "${harbor_tag}" '
+    map(select(any((.tags // [])[]?; (.name // "") == $tag)))
+  ' <<< "${all_artifacts}")
+fi
+
+match_count=$(jq 'length' <<< "${matching_artifacts}")
+echo "Matched ${match_count} artifact(s) by ${match_mode}."
+
+if [[ "${match_count}" -eq 0 ]]; then
+  write_empty_outputs
+  exit 0
+fi
+
+selected_artifact=$(jq -c '
+  sort_by(.push_time // .tags[0].push_time // "")
+  | reverse
+  | .[0]
+' <<< "${matching_artifacts}")
+
+selected_tag=$(jq -r \
+  --arg ignore "${ignore_tag_pattern}" \
+  --arg alias "${alias_tag_pattern}" '
+  def newest_non_ignored_tag($ignore):
+    (
+      (.tags // [])
+      | map(select(((.name // "") | test($ignore; "i")) | not))
+      | sort_by(.push_time // "")
+      | reverse
+      | .[0].name // ""
+    );
+  def newest_preferred_tag($ignore; $alias):
+    (
+      (.tags // [])
+      | map(select(((.name // "") | test($ignore; "i")) | not))
+      | map(select(((.name // "") | test($alias; "i")) | not))
+      | sort_by(.push_time // "")
+      | reverse
+      | .[0].name // ""
+    );
+  newest_preferred_tag($ignore; $alias) as $preferred
+  | if $preferred != "" then $preferred else newest_non_ignored_tag($ignore) end
+' <<< "${selected_artifact}")
+
+if [[ -z "${selected_tag}" ]]; then
+  write_empty_outputs
+  exit 0
+fi
+
+build_sha=$(jq -r '.extra_attrs.config.Labels.GitInfo.commitId // ""' <<< "${selected_artifact}")
+artifact_digest=$(jq -r '.digest // ""' <<< "${selected_artifact}")
+artifact_push_time=$(jq -r '.push_time // ""' <<< "${selected_artifact}")
+image_ref="${harbor_base_url#https://}/${harbor_project}/${harbor_repository}:${selected_tag}"
+
+{
+  echo "found_match=true"
+  echo "selected_tag=${selected_tag}"
+  echo "version_number=${selected_tag}"
+  echo "build_sha=${build_sha}"
+  echo "image_ref=${image_ref}"
+  echo "artifact_digest=${artifact_digest}"
+  echo "artifact_push_time=${artifact_push_time}"
+} >> "$GITHUB_OUTPUT"

--- a/.github/actions/Resolve-Harbor-Artifact/resolve_harbor_artifact.sh
+++ b/.github/actions/Resolve-Harbor-Artifact/resolve_harbor_artifact.sh
@@ -10,6 +10,9 @@ registry_token="${INPUT_REGISTRY_TOKEN:-}"
 ignore_tag_pattern="${INPUT_IGNORE_TAG_PATTERN:-^latest$}"
 alias_tag_pattern="${INPUT_ALIAS_TAG_PATTERN:-^(rc\\.|r\\.|buildall\\.)}"
 
+echo "commit_sha: ${commit_sha}"
+echo "harbor_tag: ${harbor_tag}"
+
 write_empty_outputs() {
   {
     echo "found_match=false"

--- a/.github/actions/Resolve-Harbor-Artifact/resolve_harbor_artifact.sh
+++ b/.github/actions/Resolve-Harbor-Artifact/resolve_harbor_artifact.sh
@@ -107,24 +107,18 @@ lookup_failed='false'
 while true; do
   url="${harbor_base_url}/api/v2.0/projects/${project_uri}/repositories/${repo_uri}/artifacts?page=${page}&page_size=${page_size}&with_tag=true"
   echo "url:  ${url}"
-  nslookup harbor.mt-ss.cdcr.ca.gov 2>/dev/null || true
-  echo "***** after nslookup"
   response_file=$(mktemp)
 
   if ! http_code=$(call_harbor_api "${url}" "${response_file}"); then
-    echo "***** lookup failed"
     lookup_failed='true'
     echo "Harbor lookup failed on page ${page} with HTTP ${http_code}."
     rm -f "${response_file}"
     break
   fi
-  echo "***** lookup succeeded"
 
   page_artifacts=$(cat "${response_file}")
   rm -f "${response_file}"
 
-  echo "page_artifacts: ${page_artifacts}"
-  echo "***** before count"
   page_count=$(jq 'length' <<< "${page_artifacts}")
   if [[ "${page_count}" -eq 0 ]]; then
     break

--- a/.github/actions/Resolve-Harbor-Artifact/resolve_harbor_artifact.sh
+++ b/.github/actions/Resolve-Harbor-Artifact/resolve_harbor_artifact.sh
@@ -112,6 +112,7 @@ while true; do
   if [[ "${page_count}" -eq 0 ]]; then
     break
   fi
+  echo "page_count: ${page_count}"
 
   all_artifacts=$(jq -c --argjson newPage "${page_artifacts}" '. + $newPage' <<< "${all_artifacts}")
 
@@ -130,7 +131,7 @@ fi
 
 if [[ "${match_mode}" == "commit_sha" ]]; then
   matching_artifacts=$(jq -c --arg commit "${commit_sha}" '
-    map(select((.extra_attrs.config.Labels.GitInfo.commitId // "") == $commit))
+    map(select(((.extra_attrs.config.Labels.GitInfo | fromjson? | .commitId) // "") == $commit))
   ' <<< "${all_artifacts}")
 else
   matching_artifacts=$(jq -c --arg tag "${harbor_tag}" '
@@ -181,7 +182,7 @@ if [[ -z "${selected_tag}" ]]; then
   exit 0
 fi
 
-build_sha=$(jq -r '.extra_attrs.config.Labels.GitInfo.commitId // ""' <<< "${selected_artifact}")
+build_sha=$(jq -r '(.extra_attrs.config.Labels.GitInfo | fromjson? | .commitId) // ""' <<< "${selected_artifact}")
 artifact_digest=$(jq -r '.digest // ""' <<< "${selected_artifact}")
 artifact_push_time=$(jq -r '.push_time // ""' <<< "${selected_artifact}")
 image_ref="${harbor_base_url#https://}/${harbor_project}/${harbor_repository}:${selected_tag}"

--- a/.github/actions/Resolve-Harbor-Artifact/resolve_harbor_artifact.sh
+++ b/.github/actions/Resolve-Harbor-Artifact/resolve_harbor_artifact.sh
@@ -132,6 +132,8 @@ if [[ "${lookup_failed}" == "true" ]]; then
   exit 0
 fi
 
+echo "All artifact commitIds: $(jq -r '[.[].extra_attrs.config.Labels.GitInfo | fromjson? | .commitId // ""] | join(", ")' <<< "${all_artifacts}")"
+
 if [[ "${match_mode}" == "commit_sha" ]]; then
   matching_artifacts=$(jq -c --arg commit "${commit_sha}" '
     map(select(((.extra_attrs.config.Labels.GitInfo | fromjson? | .commitId) // "") == $commit))

--- a/.github/actions/Resolve-Harbor-Artifact/resolve_harbor_artifact.sh
+++ b/.github/actions/Resolve-Harbor-Artifact/resolve_harbor_artifact.sh
@@ -90,7 +90,7 @@ lookup_failed='false'
 while true; do
   url="${harbor_base_url}/api/v2.0/projects/${project_uri}/repositories/${repo_uri}/artifacts?page=${page}&page_size=${page_size}&with_tag=true"
   echo "url:  ${url}"
-  nslookup harbor.mt-ss.cdcr.ca.gov 2>/dev/null
+  nslookup harbor.mt-ss.cdcr.ca.gov 2>/dev/null || true
   response_file=$(mktemp)
 
   if ! http_code=$(call_harbor_api "${url}" "${response_file}"); then

--- a/.github/actions/Resolve-Harbor-Artifact/resolve_harbor_artifact.sh
+++ b/.github/actions/Resolve-Harbor-Artifact/resolve_harbor_artifact.sh
@@ -89,6 +89,7 @@ lookup_failed='false'
 
 while true; do
   url="${harbor_base_url}/api/v2.0/projects/${project_uri}/repositories/${repo_uri}/artifacts?page=${page}&page_size=${page_size}&with_tag=true"
+  echo "url:  ${url}"
   response_file=$(mktemp)
 
   if ! http_code=$(call_harbor_api "${url}" "${response_file}"); then

--- a/.github/actions/Resolve-Harbor-Artifact/resolve_harbor_artifact.sh
+++ b/.github/actions/Resolve-Harbor-Artifact/resolve_harbor_artifact.sh
@@ -106,6 +106,8 @@ while true; do
   page_artifacts=$(cat "${response_file}")
   rm -f "${response_file}"
 
+  echo "page_artifacts: ${page_artifacts}"
+  echo "***** before count"
   page_count=$(jq 'length' <<< "${page_artifacts}")
   if [[ "${page_count}" -eq 0 ]]; then
     break

--- a/.github/actions/Resolve-Harbor-Artifact/resolve_harbor_artifact.sh
+++ b/.github/actions/Resolve-Harbor-Artifact/resolve_harbor_artifact.sh
@@ -56,15 +56,24 @@ call_harbor_api() {
   local url="$1"
   local response_file="$2"
   local http_code
+  local rc=0
 
-  http_code=$(curl -sS -k -o "${response_file}" -w "%{http_code}" "${url}")
+  http_code=$(curl -sS -k -o "${response_file}" -w "%{http_code}" "${url}") || rc=$?
+  if [[ $rc -ne 0 ]]; then
+    echo "000"
+    return 1
+  fi
   if [[ "${http_code}" == "200" ]]; then
     echo "${http_code}"
     return 0
   fi
 
   if [[ ${#auth_args[@]} -gt 0 ]]; then
-    http_code=$(curl -sS -k -o "${response_file}" -w "%{http_code}" "${auth_args[@]}" "${url}")
+    http_code=$(curl -sS -k -o "${response_file}" -w "%{http_code}" "${auth_args[@]}" "${url}") || rc=$?
+    if [[ $rc -ne 0 ]]; then
+      echo "000"
+      return 1
+    fi
     if [[ "${http_code}" == "200" ]]; then
       echo "${http_code}"
       return 0
@@ -73,7 +82,11 @@ call_harbor_api() {
     if [[ "${registry_token}" == *:* ]]; then
       local basic_auth
       basic_auth=$(printf "%s" "${registry_token}" | base64 | tr -d '\n')
-      http_code=$(curl -sS -k -o "${response_file}" -w "%{http_code}" -H "Authorization: Basic ${basic_auth}" "${url}")
+      http_code=$(curl -sS -k -o "${response_file}" -w "%{http_code}" -H "Authorization: Basic ${basic_auth}" "${url}") || rc=$?
+      if [[ $rc -ne 0 ]]; then
+        echo "000"
+        return 1
+      fi
       if [[ "${http_code}" == "200" ]]; then
         echo "${http_code}"
         return 0

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Folder for local stuff
+.local/


### PR DESCRIPTION
A custom action that returns data about an image/artifact in Harbor based on its commit SHA or tag.

This is originally built for use in [AB#26928](https://dev.azure.com/cdcr/804cc419-ce20-4215-96ee-413c51e4578f/_workitems/edit/26928) which suppresses builds when an image already exists for the same commit. However, I anticipate it being used in other contexts in the future.